### PR TITLE
About page initial top text and iconography

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,11 +48,9 @@
 								<div class="spotlight">
 									<div class="content">
 										<header class="major">
-											<h2>Ipsum sed adipiscing</h2>
+											<h2>What is symphony club?</h2>
 										</header>
-										<p>Sed lorem ipsum dolor sit amet nullam consequat feugiat consequat magna
-										adipiscing magna etiam amet veroeros. Lorem ipsum dolor tempus sit cursus.
-										Tempus nisl et nullam lorem ipsum dolor sit amet aliquam.</p>
+										<p>Symphony club is a conjunction between band and orchestra which provides a fun opportunity for band and orchestra musicians to make music, collaborate together, and to discover standard orchestral repetoire.</p>
 										<ul class="actions">
 											<li><a href="pages/generic.html" class="button">Learn More</a></li>
 										</ul>
@@ -64,23 +62,23 @@
 						<!-- First Section -->
 							<section id="first" class="main special">
 								<header class="major">
-									<h2>Magna veroeros</h2>
+									<h2>Opportunities</h2>
 								</header>
 								<ul class="features">
 									<li>
-										<span class="icon solid major style1 fa-code"></span>
-										<h3>Ipsum consequat</h3>
-										<p>Sed lorem amet ipsum dolor et amet nullam consequat a feugiat consequat tempus veroeros sed consequat.</p>
+										<span class="icon solid major style1 fa-music"></span>
+										<h3>Play in an complete symphony orchestra</h3>
+										<p>Symphony club allows for band and orchestra students at Eastlake to play together and introduce themselves to more repetoire.</p>
 									</li>
 									<li>
-										<span class="icon major style3 fa-copy"></span>
-										<h3>Amed sed feugiat</h3>
-										<p>Sed lorem amet ipsum dolor et amet nullam consequat a feugiat consequat tempus veroeros sed consequat.</p>
+										<span class="icon major style3 fa-calendar-check"></span>
+										<h3>Weekly rehersals and concert performances</h3>
+										<p>Throughout the year symphony club will weekly rehersals in preparation for a series of professional performances.</p>
 									</li>
 									<li>
-										<span class="icon major style5 fa-gem"></span>
-										<h3>Dolor nullam</h3>
-										<p>Sed lorem amet ipsum dolor et amet nullam consequat a feugiat consequat tempus veroeros sed consequat.</p>
+										<span class="icon solid major style2 fa-clipboard-check"></span>
+										<h3>Leadership opportunities</h3> <br>
+										<p>Symphony club has several leadership positions which allow members to take charge and maintain their own club.</p>
 									</li>
 								</ul>
 								<footer class="major">


### PR DESCRIPTION
<!-- (Optional) The issue this closes -->
Closes #

## This pull request:
<!-- Add a list of what this pull request adds/fixes -->  

- Adds the initial text for the first two sections of the about page on the site.
- Adds icons to the same page using fontawesome.

## Context:
<!-- Add any context about the pull request here -->
Adding onto previous additions to the site like the page tabs and titles.

## Screenshots
<!-- If you have any, add screenshots here -->
![image](https://user-images.githubusercontent.com/65648604/121229692-21c73700-c843-11eb-8690-877343a3e69f.png)

TODO: Add image to top of about page.
